### PR TITLE
deleteCheckedtodos task

### DIFF
--- a/lib/providers/todo_provider.dart
+++ b/lib/providers/todo_provider.dart
@@ -9,7 +9,7 @@ class TodoProvider extends ChangeNotifier {
   late final titleController = TextEditingController();
   late final descriptionController = TextEditingController();
 
-  List<TodoModel> _todos = [];
+  final List<TodoModel> _todos = [];
   final List<TodoModel> _deletedTodos = [];
 
   List<TodoModel> get deletedTodos => _deletedTodos;
@@ -88,6 +88,11 @@ class TodoProvider extends ChangeNotifier {
     _deletedTodos.clear();
     notifyListeners();
   }
+
+  void deleteCheckedTodos() {
+  _deletedTodos.removeWhere((todo) => todo.isChecked);
+  notifyListeners();
+}
 
   void _clearInputsAndCloseSheet(BuildContext context) {
     Go.pop(context);

--- a/lib/ui/pages/delete/delete_page.dart
+++ b/lib/ui/pages/delete/delete_page.dart
@@ -68,7 +68,7 @@ class DeletePage extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           FloatingActionButton(
-            onPressed: () {},
+            onPressed: () => todoProvider.deleteCheckedTodos(),
             child: const Icon(Icons.clear),
           ),
           10.h,

--- a/lib/ui/widgets/custom_tile.dart
+++ b/lib/ui/widgets/custom_tile.dart
@@ -38,6 +38,7 @@ class _CustomTileState extends State<CustomTile> {
       child: ListTile(
         onTap: () {
           _isChecked = !_isChecked;
+           widget.todo.isChecked = _isChecked;
           setState(() {});
         },
         title: Text(
@@ -53,6 +54,7 @@ class _CustomTileState extends State<CustomTile> {
           value: _isChecked,
           onChanged: (v) {
             _isChecked = v!;
+            widget.todo.isChecked = v;
             setState(() {});
           },
         ),


### PR DESCRIPTION
-Customtile widgetinde actual todo modelin yenilenmesi ucun lines elave edildi.
- providerde yeni deleteCheckedTodos metodu elave etdim. burada todo.isChecked o demekdir ki, eger check zamani dogrudursa sistemden silinsin.
- delete sehifesinde ise onpress zamani metodu elave etdim ki istifadecei clear buttona klik edende deleteCheckedTodos() metodu cagrilir, bu zaman provider ischecked true olanlari silir ve ekran update olunur ki secilmeyen diger todolar gorsensin.